### PR TITLE
Added support for limiting experiments to a subset of traffic

### DIFF
--- a/sixpack/sixpack.py
+++ b/sixpack/sixpack.py
@@ -38,7 +38,7 @@ class Session(object):
         else:
             self.client_id = client_id
 
-    def participate(self, experiment_name, alternatives, force=None, traffic_dist=None):
+    def participate(self, experiment_name, alternatives, force=None, traffic_fraction=1):
         if VALID_NAME_RE.match(experiment_name) is None:
             raise ValueError('Bad experiment name')
 
@@ -58,10 +58,9 @@ class Session(object):
         if force is not None and force in alternatives:
             params['force'] = force
 
-        if traffic_dist is not None:
-            if int(traffic_dist) < 0 or int(traffic_dist) > 100:
-                raise ValueError('Bad traffic_dist specified (should be a number between 0 and 100')
-            params['traffic_dist'] = str(traffic_dist)
+        if float(traffic_fraction) < 0 or float(traffic_fraction) > 1:
+            raise ValueError('Bad traffic_fraction specified (should be a number between 0 and 1')
+        params['traffic_fraction'] = str(traffic_fraction)
 
         response = self.get_response('/participate', params)
         if response['status'] == 'failed':

--- a/sixpack/test/test_sixpack_client.py
+++ b/sixpack/test/test_sixpack_client.py
@@ -75,16 +75,16 @@ class TestSixpackClent(unittest.TestCase):
         ret = session.convert('with-kpi', kpi='my-shiny-kpi')
         self.assertEqual(ret['status'], 'ok')
 
-    def test_should_return_ok_for_a_traffic_dist(self):
+    def test_should_return_ok_for_a_traffic_fraction(self):
         session = sixpack.Session('supperUser')
-        session.participate('my-subset-experiment', ['water', 'oil'], traffic_dist=20)
+        session.participate('my-subset-experiment', ['water', 'oil'], traffic_fraction=0.2)
         ret = session.convert('my-subset-experiment')
         self.assertEqual(ret['status'], 'ok')
 
-    def test_should_return_error_for_a_traffic_dist_off_the_charts(self):
+    def test_should_return_error_for_a_traffic_fraction_off_the_charts(self):
         session = sixpack.Session('runnerOsvaldo')
         with self.assertRaises(ValueError):
-            session.participate('subset-experiment', ['water', 'oil'], traffic_dist=500)
+            session.participate('subset-experiment', ['water', 'oil'], traffic_fraction=5)
 
     def test_failure_on_too_few_alts(self):
         session = sixpack.Session('zack')


### PR DESCRIPTION
This commit intends to support the optional traffic_dist param:

traffic_dist (optional) sixpack allows for limiting experiments to a subset of traffic. You can pass the percentage of traffic you'd like to expose the test to as a whole number here. (traffic_dist=10 for 10%)
