### PR TITLE
Fixed error in reporting non-200 status from server. (closes #7)

### DIFF
--- a/sixpack/sixpack.py
+++ b/sixpack/sixpack.py
@@ -101,7 +101,7 @@ class Session(object):
         try:
             response = requests.get(url, params=params, timeout=self.timeout)
             if response.status_code != 200:
-                ret = "{\"status\": \"failed\", \"response\": {0}}".format(response.content)
+                ret = "{{\"status\": \"failed\", \"response\": {0}}}".format(response.content)
             else:
                 ret = response.content
         except:


### PR DESCRIPTION
Using `{{` and `}}` instead of `{` and `}` in the format string solved the issue.