### PR TITLE
Don't hardcode requests version in dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests==0.13.7
+requests


### PR DESCRIPTION
Don't pin the exact (and very, very old) version of the requests library
in requirements.txt. Pinning is something that is considered best
practice for applications, but not libraries that other code may depend
on. Don't put any upper bound on permitted versions, because user code
will want to use the latest possible version (and sixpack-py seems to
work with the current 2.6.0 version without issues). Making the
requirement be explicitly >=0.13.7 seems pointless given that version's
age, so just put "requests" there for now. Should an incompatibility
with some old version be found, this should be replaced with a >= test.

Fixes #5.