### PR TITLE
Python 3 compatibility

### DIFF
--- a/sixpack/sixpack.py
+++ b/sixpack/sixpack.py
@@ -106,10 +106,12 @@ class Session(object):
         try:
             response = requests.get(url, params=params, timeout=self.timeout)
             if response.status_code != 200:
-                ret = "{{\"status\": \"failed\", \"response\": {0}}}".format(response.content)
+                try:
+                    content = response.json()
+                except Exception:
+                    content = response.content
+                return {{"status": "failed", "response": content}}
             else:
-                ret = response.content
+                return response.json()
         except Exception:
-                ret = "{\"status\": \"failed\", \"response\": \"http error: sixpack is unreachable\"}"
-
-        return json.loads(ret)
+            return {"status": "failed", "response": "http error: sixpack is unreachable"}


### PR DESCRIPTION
This PR fixes a single issue with Python 3 compatibility that I encountered: JSON decoding is done semi-manually and incompatibly with Python 3 (string vs bytes difference). Rather than reinvent the wheel, this PR uses the `json()` helper method available Requests. 

I can’t vouch for the entirety of the module, but basic participate/convert usage now works under Python 3 (I’m using this patch in production now).

Details: 

> In Session.get_response(), don't pass response.content directly to
> json.loads(), because the former is a bytes array while loads() expects
> a string in Python 3. Rather than doing explicit conversion, use the
> builtin response.json() method.
> 
> Also return error response as dictionaries instead of needlessly
> round-tripping them through JSON. This avoids the need to deal with
> their encoding.