### PR TITLE
Make requests json encoding Python3 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: python
 python:
   - "2.7"
+  - "3.4"
 install: "pip install -r requirements.txt"
-before_script: "pip install nose-cov"
+before_script: "pip install nose-cov mock"
 script: nosetests --with-coverage --cover-package=sixpack
 sudo: false
 cache: pip

--- a/sixpack/sixpack.py
+++ b/sixpack/sixpack.py
@@ -1,4 +1,3 @@
-import json
 import re
 import requests
 from uuid import uuid4
@@ -105,11 +104,13 @@ class Session(object):
 
         try:
             response = requests.get(url, params=params, timeout=self.timeout)
-            if response.status_code != 200:
-                ret = "{{\"status\": \"failed\", \"response\": {0}}}".format(response.content)
-            else:
-                ret = response.content
         except Exception:
-                ret = "{\"status\": \"failed\", \"response\": \"http error: sixpack is unreachable\"}"
+            return {"status": "failed", "response": "http error: sixpack is unreachable"}
 
-        return json.loads(ret)
+        if response.status_code != 200:
+            return {"status": "failed", "response": response.content}
+
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": "failed", "response": response.content}

--- a/sixpack/test/test_sixpack_client.py
+++ b/sixpack/test/test_sixpack_client.py
@@ -111,14 +111,15 @@ class TestSixpackClent(unittest.TestCase):
 def new_convert(*args, **kwargs):
     m = Mock()
     m.status_code = 200
-    m.content = '{"status": "ok"}'
+    m.json.return_value = {"status": "ok"}
+
     return m
 
 
 def new_participate(*args, **kwargs):
     m = Mock()
     m.status_code = 200
-    m.content = '{"status": "ok"}'
+    m.json.return_value = {"status": "ok"}
 
     return m
 


### PR DESCRIPTION
These changes allow compatibility with python3.
Tests and travis script have been updated as well.

I'v seen https://github.com/seatgeek/sixpack-py/pull/15, but since it's open for several months and hasn't been merged, I decided to open a new PR.